### PR TITLE
  Add support for passing function source and add missing function from py3/dispy/__init__.py

### DIFF
--- a/py3/dispy.py
+++ b/py3/dispy.py
@@ -54,6 +54,45 @@ handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(message)s'))
 logger.addHandler(handler)
 del handler
 
+def isfunction(func, allow_method=False):
+    return inspect.isfunction(func) \
+                or allow_method and inspect.ismethod(func) \
+                or isinstance(func, str) and '\n' in func
+
+def get_function(func):
+    if isinstance(func, str):
+        env = {}
+        exec func in env
+        names = env.keys()
+        names.remove('__builtins__')
+        assert len(names) == 1, "Provided source code must only provide one function."
+        return env[names[0]]
+    return func
+
+def get_function_args(func, min_args=0, max_args=0):
+    func = get_function(func)
+    args = inspect.getargspec(func)
+    if type(func) == types.MethodType:
+        assert len(args.args) <= max_args+1, "Method `%s` has too many arguments (maximum allowed = %d)." % (func.func_name, max_args+1)
+        assert len(args.args) >= min_args+1, "Method `%s` has too few arguments (minimum alloed = %d)." % (func.func_name, min_args+1)
+        if args.args[0] != 'self':
+            logger.warning('First argument to callback method is not "self".')
+    else:
+        assert len(args.args) <= max_args, "Function `%s` has too many arguments (maximum allowed = %d)." % (func.func_name, max_args)
+        assert len(args.args) >= min_args, "Function `%s` has too few arguments (minimum allowed = %d)." % (func.func_name, min_args)
+    assert args.varargs is None
+    assert args.keywords is None
+    assert args.defaults is None
+    return args
+
+def get_function_source(func):
+    if isinstance(func, str):
+        return func.lstrip()
+    else:
+        lines = inspect.getsourcelines(func)[0]
+        lines[0] = lines[0].lstrip()
+        return ''.join(lines)
+
 class DispyJob(object):
     """Job scheduled for execution with dispy.
 
@@ -1178,7 +1217,7 @@ class _Cluster(object):
                     break
         if node_computations:
             Coro(self.setup_node, node, node_computations)
-                
+
     def worker(self):
         # used for user callbacks only
         while True:
@@ -1533,7 +1572,7 @@ class _Cluster(object):
             cpus = int(cpus)
         except ValueError:
             raise StopIteration(-1)
-        node = _node_ipaddr(node)        
+        node = _node_ipaddr(node)
         node = self._nodes.get(node, None)
         if node is None:
             cpus = -1
@@ -1690,7 +1729,7 @@ class JobCluster(object):
 
         @ext_ip_addr is the IP address of NAT firewall/gateway if
           dispy client is behind that firewall/gateway.
-        
+
         @node_port indicates port on which node servers are listening
           for ping messages. The client (JobCluster instance) broadcasts
           ping requests to this port.
@@ -1700,7 +1739,7 @@ class JobCluster(object):
           transferred to a server node when executing a job.  If
           @computation is a string, indicating a program, then that
           program is also transferred to @dest_path.
-        
+
         @loglevel indicates message priority for logging module.
 
         @cleanup indicates if the files transferred should be removed when
@@ -1797,16 +1836,7 @@ class JobCluster(object):
             assert inspect.isfunction(callback) or inspect.ismethod(callback), \
                    "callback must be a function or method"
             try:
-                args = inspect.getargspec(callback)
-                if inspect.isfunction(callback):
-                    assert len(args.args) == 1
-                else:
-                    assert len(args.args) == 2
-                    if args.args[0] != 'self':
-                        logger.warning('First argument to callback method is not "self"')
-                assert args.varargs is None
-                assert args.keywords is None
-                assert args.defaults is None
+                args = get_function_args(callback, min_args=1, max_args=1)
             except:
                 raise Exception('Invalid callback function; '
                                 'it must take excatly one argument - an instance of DispyJob')
@@ -1816,16 +1846,7 @@ class JobCluster(object):
             assert inspect.isfunction(cluster_status) or inspect.ismethod(cluster_status), \
                    "cluster_status must be a function or method"
             try:
-                args = inspect.getargspec(cluster_status)
-                if inspect.isfunction(cluster_status):
-                    assert len(args.args) == 3
-                else:
-                    assert len(args.args) == 4
-                    if args.args[0] != 'self':
-                        logger.warning('First argument to cluster_status method is not "self"')
-                assert args.varargs is None
-                assert args.keywords is None
-                assert args.defaults is None
+                args = get_function_args(cluster_status, min_args=3, max_args=3)
             except:
                 raise Exception('Invalid cluster_status function; '
                                 'it must take excatly 3 arguments')
@@ -1837,12 +1858,12 @@ class JobCluster(object):
             shared = False
 
         if setup:
-            assert inspect.isfunction(setup), "setup must be Python function"
+            assert isfunction(setup), "setup must be Python function or the string source thereof"
             depends.append(setup)
 
         if cleanup:
             if cleanup is not True:
-                assert inspect.isfunction(cleanup), "cleanup must be Python function"
+                assert isfunction(cleanup), "cleanup must be Python function or the string source thereof"
                 depends.append(cleanup)
 
         if fault_recover:
@@ -1879,12 +1900,10 @@ class JobCluster(object):
         atexit.register(self.shutdown)
         # self.ip_addr = self._cluster.ip_addr
 
-        if inspect.isfunction(computation):
-            func = computation
+        if isfunction(computation):
+            func = get_function(computation)
             compute = _Compute(_Compute.func_type, func.__name__)
-            lines = inspect.getsourcelines(func)[0]
-            lines[0] = lines[0].lstrip()
-            compute.code = ''.join(lines)
+            compute.code = get_function_source(computation)
         elif isinstance(computation, str):
             compute = _Compute(_Compute.prog_type, computation)
             depends.append(computation)
@@ -1892,7 +1911,7 @@ class JobCluster(object):
             raise Exception('Invalid computation type: %s' % type(compute))
         depend_ids = {}
         for dep in depends:
-            if isinstance(dep, str) or inspect.ismodule(dep):
+            if isinstance(dep, str) and not isfunction(dep) or inspect.ismodule(dep):
                 if inspect.ismodule(dep):
                     dep = dep.__file__
                     if dep.endswith('.pyc'):
@@ -1918,8 +1937,8 @@ class JobCluster(object):
                     depend_ids[dep] = dep
                 except:
                     raise Exception('File "%s" is not valid' % dep)
-            elif inspect.isfunction(dep) or inspect.isclass(dep) or hasattr(dep, '__class__'):
-                if inspect.isfunction(dep) or inspect.isclass(dep):
+            elif isfunction(dep) or inspect.isclass(dep) or hasattr(dep, '__class__'):
+                if type(dep) == str or inspect.isfunction(dep) or inspect.isclass(dep):
                     pass
                 elif hasattr(dep, '__class__') and inspect.isclass(dep.__class__):
                     dep = dep.__class__
@@ -1927,9 +1946,7 @@ class JobCluster(object):
                     continue
                 if compute.type == _Compute.prog_type:
                     raise Exception('Program computations cannot depend on "%s"' % dep.__name__)
-                lines = inspect.getsourcelines(dep)[0]
-                lines[0] = lines[0].lstrip()
-                compute.code += '\n' + ''.join(lines)
+                compute.code += '\n' + get_function_source(dep)
                 depend_ids[id(dep)] = id(dep)
             else:
                 raise Exception('Invalid function: %s' % dep)
@@ -1953,12 +1970,12 @@ class JobCluster(object):
         compute.reentrant = reentrant
         compute.pulse_interval = pulse_interval
         compute.poll_interval = poll_interval
-        if inspect.isfunction(setup):
-            compute.setup = setup.__name__
+        if isfunction(setup):
+            compute.setup = get_function(setup).__name__
         else:
             compute.setup = None
-        if inspect.isfunction(cleanup):
-            compute.cleanup = cleanup.__name__
+        if isfunction(cleanup):
+            compute.cleanup = get_function(cleanup).__name__
         else:
             compute.cleanup = cleanup
 
@@ -2132,7 +2149,7 @@ class SharedJobCluster(JobCluster):
             for ext_ip_addr in self._cluster.ext_ip_addrs:
                 if not ext_ip_addr:
                     break
-                
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock = AsyncSocket(sock, blocking=True, keyfile=keyfile, certfile=certfile)
         sock.connect((self.scheduler_ip_addr, scheduler_port))
@@ -2601,7 +2618,7 @@ if __name__ == '__main__':
     else:
         del config['scheduler_node']
         cluster = JobCluster(**config)
-                
+
     jobs = []
     for n, arg in enumerate(args, start=1):
         job = cluster.submit(*(arg.split()))


### PR DESCRIPTION
Greetings again pgiri,

Sorry about the shuffle. I realised a pull request from my master branch was a bad idea as it meant I could not easily update the pull request with respect to your changes. Below is the original message, along with your reply:
------------------------
I spoke once before with you about adding support for providing to Dispy the source code of python functions rather than the functions themselves. I'm not sure if I made the use case for this clear, but it is necessary in my use case.

The main use case is as follows: Suppose you have some complex class with many runtime variable properties, none of which will be accessible when the setup/cleanup/computation functions are run in the new environment of dispynode; and yet you need access to these properties to properly reconstruct your object. One solution, as I have implemented it, is to send the source code, rather than the Python function. The source code can then be "formatted" with the values of the properties you need. Sending an 'exec'ed version will not work, because inspect.getsourcelines requires that the python function be associated with a filename on the hard drive.

In the process of implementing this, I discovered that one of the python 3 modules for dispy was lacking the stats function; and so I also rectified that.

Any thoughts on this? If you're not keen to include it, I'm okay with that. But if there are things you want addressed with my patch, let me know, and I'll improve it :).

----------------

I will go through it again; it seems fairly extensive.

I am not sure if I am missing something, but I believe you can send classes in 'depends' parameter. Then even 'setup' will be able to use objects (class instances). Can you give an example that needs this patch?
