### PR TITLE
Fix namespace issues with submitted code, better compartmentalise computations and allow populating namespace with python objects.

### DIFF
--- a/py2/dispy.py
+++ b/py2/dispy.py
@@ -247,6 +247,7 @@ class _Compute(object):
         self.name = name
         self.id = None
         self.code = None
+        self.context = {}
         self.dest_path = None
         self.xfer_files = []
         self.reentrant = False

--- a/py2/dispy.py
+++ b/py2/dispy.py
@@ -1638,7 +1638,7 @@ class JobCluster(object):
     """Create an instance of cluster for a specific computation.
     """
 
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, node_port=None, ext_ip_addr=None,
                  dest_path=None, loglevel=logging.INFO, setup=None, cleanup=True,
                  ping_interval=None, pulse_interval=None, poll_interval=None,
@@ -1663,6 +1663,12 @@ class JobCluster(object):
           If the element is a python object (a function name, class name etc.),
           then the code for that object is transferred to the node executing
           a job for this cluster.
+
+        @context is a dictionary. Each key should correspond to a valid
+          variable name that will be made available in the namespace of
+          `setup`, `compute` and `cleanup`. The value associated with each
+          key should be a pickleable python object. If the class of the object
+          is not installed on the server, it should be added to `depends`.
 
        @callback is a function or class method. When a job's results
           become available, dispy will call provided callback
@@ -1921,6 +1927,7 @@ class JobCluster(object):
             # make sure code can be compiled
             code = compile(compute.code, '<string>', 'exec')
             del code
+        compute.context = context
         if dest_path:
             if not isinstance(dest_path, str):
                 raise Exception('Invalid dest_path: it must be a string')
@@ -2077,7 +2084,7 @@ class SharedJobCluster(JobCluster):
     dispyscheduler must be called with appropriate pulse_interval.
     The behaviour is same as for JobCluster.
     """
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, scheduler_node=None, scheduler_port=None,
                  ext_ip_addr=None, loglevel=logging.INFO, setup=None, cleanup=True, dest_path=None,
                  poll_interval=None, reentrant=False, secret='',
@@ -2100,7 +2107,7 @@ class SharedJobCluster(JobCluster):
         if not node_specs:
             raise Exception('"nodes" argument is invalid')
 
-        JobCluster.__init__(self, computation, depends=depends,
+        JobCluster.__init__(self, computation, depends=depends, context=context,
                             callback=callback, cluster_status=cluster_status,
                             ip_addr=ip_addr, port=port, ext_ip_addr=ext_ip_addr,
                             loglevel=loglevel, setup=setup, cleanup=cleanup, dest_path=dest_path,

--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -247,6 +247,7 @@ class _Compute(object):
         self.name = name
         self.id = None
         self.code = None
+        self.context = {}
         self.dest_path = None
         self.xfer_files = []
         self.reentrant = False

--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -1638,7 +1638,7 @@ class JobCluster(object):
     """Create an instance of cluster for a specific computation.
     """
 
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, node_port=None, ext_ip_addr=None,
                  dest_path=None, loglevel=logging.INFO, setup=None, cleanup=True,
                  ping_interval=None, pulse_interval=None, poll_interval=None,
@@ -1663,6 +1663,12 @@ class JobCluster(object):
           If the element is a python object (a function name, class name etc.),
           then the code for that object is transferred to the node executing
           a job for this cluster.
+
+        @context is a dictionary. Each key should correspond to a valid
+          variable name that will be made available in the namespace of
+          `setup`, `compute` and `cleanup`. The value associated with each
+          key should be a pickleable python object. If the class of the object
+          is not installed on the server, it should be added to `depends`.
 
        @callback is a function or class method. When a job's results
           become available, dispy will call provided callback
@@ -1921,6 +1927,7 @@ class JobCluster(object):
             # make sure code can be compiled
             code = compile(compute.code, '<string>', 'exec')
             del code
+        compute.context = context
         if dest_path:
             if not isinstance(dest_path, str):
                 raise Exception('Invalid dest_path: it must be a string')
@@ -2077,7 +2084,7 @@ class SharedJobCluster(JobCluster):
     dispyscheduler must be called with appropriate pulse_interval.
     The behaviour is same as for JobCluster.
     """
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, scheduler_node=None, scheduler_port=None,
                  ext_ip_addr=None, loglevel=logging.INFO, setup=None, cleanup=True, dest_path=None,
                  poll_interval=None, reentrant=False, secret='',
@@ -2100,7 +2107,7 @@ class SharedJobCluster(JobCluster):
         if not node_specs:
             raise Exception('"nodes" argument is invalid')
 
-        JobCluster.__init__(self, computation, depends=depends,
+        JobCluster.__init__(self, computation, depends=depends, context=context,
                             callback=callback, cluster_status=cluster_status,
                             ip_addr=ip_addr, port=port, ext_ip_addr=ext_ip_addr,
                             loglevel=loglevel, setup=setup, cleanup=cleanup, dest_path=dest_path,

--- a/py2/dispynode.py
+++ b/py2/dispynode.py
@@ -167,7 +167,7 @@ def _same_file(tgt, xf):
 
 def _dispy_job_func(__dispy_job_info, __dispy_job_certfile, __dispy_job_keyfile,
                     __dispy_job_args, __dispy_job_kwargs, __dispy_reply_Q,
-                    __dispy_job_name, __dispy_job_code, __dispy_path):
+                    __dispy_job_name, __dispy_job_code, __dispy_job_context, __dispy_path):
     """Internal use only.
     """
     os.chdir(__dispy_path)
@@ -175,14 +175,13 @@ def _dispy_job_func(__dispy_job_info, __dispy_job_certfile, __dispy_job_keyfile,
     sys.stderr = io.StringIO()
     __dispy_job_reply = __dispy_job_info.job_reply
     try:
-        exec(marshal.loads(__dispy_job_code[0]))
+        exec(marshal.loads(__dispy_job_code[0])) in __dispy_job_context
         if __dispy_job_code[1]:
-            exec(__dispy_job_code[1])
-        globals().update(locals())
+            exec(__dispy_job_code[1]) in __dispy_job_context
         __dispy_job_args = unserialize(__dispy_job_args)
         __dispy_job_kwargs = unserialize(__dispy_job_kwargs)
-        __func = globals()[__dispy_job_name]
-        __dispy_job_reply.result = __func(*__dispy_job_args, **__dispy_job_kwargs)
+        __dispy_job_context.update(locals())
+        exec("__dispy_job_reply.result = %s(*__dispy_job_args, **__dispy_job_kwargs)" % __dispy_job_name) in __dispy_job_context
         __dispy_job_reply.status = DispyJob.Finished
     except:
         __dispy_job_reply.exception = traceback.format_exc()
@@ -477,7 +476,7 @@ class _DispyNode(object):
                 job_info = _DispyJobInfo(reply, reply_addr, compute, _job.xfer_files)
                 args = (job_info, self.certfile, self.keyfile,
                         _job.args, _job.kwargs, self.reply_Q,
-                        compute.name, (compute.code, _job.code), compute.dest_path)
+                        compute.name, (compute.code, _job.code), compute.context.copy(), compute.dest_path)
                 try:
                     yield conn.send_msg('ACK')
                 except:
@@ -699,9 +698,8 @@ class _DispyNode(object):
                 compute = self.computations[compute_id]
                 assert isinstance(compute.setup, str)
                 os.chdir(compute.dest_path)
-                exec(marshal.loads(compute.code)) in globals(), locals()
-                _dispy_setup_func = locals()[compute.setup]
-                assert _dispy_setup_func() == 0
+                exec(marshal.loads(compute.code)) in compute.context
+                exec("assert %s() == 0" % compute.setup) in compute.context
             except:
                 logger.debug('Setup "%s" failed' % compute.setup)
                 resp = traceback.format_exc().encode()
@@ -1186,9 +1184,8 @@ class _DispyNode(object):
         os.chdir(self.dest_path_prefix)
         if isinstance(compute.cleanup, str):
             try:
-                exec(marshal.loads(compute.code)) in globals(), locals()
-                _dispy_cleanup_func = locals()[compute.cleanup]
-                _dispy_cleanup_func()
+                exec(marshal.loads(compute.code)) in compute.context
+                exec("%s()" % compute.cleanup) in compute.context
             except:
                 logger.debug('cleanup "%s" failed' % compute.cleanup)
                 logger.debug(traceback.format_exc())

--- a/py3/dispy.py
+++ b/py3/dispy.py
@@ -247,6 +247,7 @@ class _Compute(object):
         self.name = name
         self.id = None
         self.code = None
+        self.context = {}
         self.dest_path = None
         self.xfer_files = []
         self.reentrant = False

--- a/py3/dispy.py
+++ b/py3/dispy.py
@@ -1638,7 +1638,7 @@ class JobCluster(object):
     """Create an instance of cluster for a specific computation.
     """
 
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, node_port=None, ext_ip_addr=None,
                  dest_path=None, loglevel=logging.INFO, setup=None, cleanup=True,
                  ping_interval=None, pulse_interval=None, poll_interval=None,
@@ -1663,6 +1663,12 @@ class JobCluster(object):
           If the element is a python object (a function name, class name etc.),
           then the code for that object is transferred to the node executing
           a job for this cluster.
+
+        @context is a dictionary. Each key should correspond to a valid
+          variable name that will be made available in the namespace of
+          `setup`, `compute` and `cleanup`. The value associated with each
+          key should be a pickleable python object. If the class of the object
+          is not installed on the server, it should be added to `depends`.
 
        @callback is a function or class method. When a job's results
           become available, dispy will call provided callback
@@ -1921,6 +1927,7 @@ class JobCluster(object):
             # make sure code can be compiled
             code = compile(compute.code, '<string>', 'exec')
             del code
+        compute.context = context
         if dest_path:
             if not isinstance(dest_path, str):
                 raise Exception('Invalid dest_path: it must be a string')
@@ -2077,7 +2084,7 @@ class SharedJobCluster(JobCluster):
     dispyscheduler must be called with appropriate pulse_interval.
     The behaviour is same as for JobCluster.
     """
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, scheduler_node=None, scheduler_port=None,
                  ext_ip_addr=None, loglevel=logging.INFO, setup=None, cleanup=True, dest_path=None,
                  poll_interval=None, reentrant=False, secret='',
@@ -2100,7 +2107,7 @@ class SharedJobCluster(JobCluster):
         if not node_specs:
             raise Exception('"nodes" argument is invalid')
 
-        JobCluster.__init__(self, computation, depends=depends,
+        JobCluster.__init__(self, computation, depends=depends, context=context,
                             callback=callback, cluster_status=cluster_status,
                             ip_addr=ip_addr, port=port, ext_ip_addr=ext_ip_addr,
                             loglevel=loglevel, setup=setup, cleanup=cleanup, dest_path=dest_path,

--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -247,6 +247,7 @@ class _Compute(object):
         self.name = name
         self.id = None
         self.code = None
+        self.context = {}
         self.dest_path = None
         self.xfer_files = []
         self.reentrant = False

--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -1638,7 +1638,7 @@ class JobCluster(object):
     """Create an instance of cluster for a specific computation.
     """
 
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, node_port=None, ext_ip_addr=None,
                  dest_path=None, loglevel=logging.INFO, setup=None, cleanup=True,
                  ping_interval=None, pulse_interval=None, poll_interval=None,
@@ -1663,6 +1663,12 @@ class JobCluster(object):
           If the element is a python object (a function name, class name etc.),
           then the code for that object is transferred to the node executing
           a job for this cluster.
+
+        @context is a dictionary. Each key should correspond to a valid
+          variable name that will be made available in the namespace of
+          `setup`, `compute` and `cleanup`. The value associated with each
+          key should be a pickleable python object. If the class of the object
+          is not installed on the server, it should be added to `depends`.
 
        @callback is a function or class method. When a job's results
           become available, dispy will call provided callback
@@ -1921,6 +1927,7 @@ class JobCluster(object):
             # make sure code can be compiled
             code = compile(compute.code, '<string>', 'exec')
             del code
+        compute.context = context
         if dest_path:
             if not isinstance(dest_path, str):
                 raise Exception('Invalid dest_path: it must be a string')
@@ -2077,7 +2084,7 @@ class SharedJobCluster(JobCluster):
     dispyscheduler must be called with appropriate pulse_interval.
     The behaviour is same as for JobCluster.
     """
-    def __init__(self, computation, nodes=None, depends=[], callback=None, cluster_status=None,
+    def __init__(self, computation, nodes=None, depends=[], context={}, callback=None, cluster_status=None,
                  ip_addr=None, port=None, scheduler_node=None, scheduler_port=None,
                  ext_ip_addr=None, loglevel=logging.INFO, setup=None, cleanup=True, dest_path=None,
                  poll_interval=None, reentrant=False, secret='',
@@ -2100,7 +2107,7 @@ class SharedJobCluster(JobCluster):
         if not node_specs:
             raise Exception('"nodes" argument is invalid')
 
-        JobCluster.__init__(self, computation, depends=depends,
+        JobCluster.__init__(self, computation, depends=depends, context=context,
                             callback=callback, cluster_status=cluster_status,
                             ip_addr=ip_addr, port=port, ext_ip_addr=ext_ip_addr,
                             loglevel=loglevel, setup=setup, cleanup=cleanup, dest_path=dest_path,


### PR DESCRIPTION
Currently, classes (and other code objects) sent from JobCluster cannot be used by setup/cleanup/compute on the server because running `exec(<code>) in locals()` does not update the free variables used by the Python interpreter (as documented here:https://docs.python.org/2/library/functions.html#locals).

```
locals()
    Update and return a dictionary representing the current local symbol table. Free variables are returned by locals() when it is called in function blocks, but not in class blocks.
    Note: The contents of this dictionary should not be modified; changes may not affect the values of local and free variables used by the interpreter.
```
This pull request fixes this, and better isolates computations from the namespace of dispy itself; improving robustness and fixing the classes issue.