### PR TITLE
Fix socket not closing in time.

### DIFF
--- a/py2/dispy/httpd.py
+++ b/py2/dispy/httpd.py
@@ -299,4 +299,6 @@ class DispyHTTPServer(object):
                 'HTTP server waiting for %s seconds for client updates before quitting',
                 self._poll_sec)
             time.sleep(self._poll_sec)
+        if self._server.socket:
+            self._server.socket.close()
         self._server.shutdown()

--- a/py3/dispy/httpd.py
+++ b/py3/dispy/httpd.py
@@ -299,4 +299,6 @@ class DispyHTTPServer(object):
                 'HTTP server waiting for %s seconds for client updates before quitting',
                 self._poll_sec)
             time.sleep(self._poll_sec)
+        if self._server.socket:
+            self._server.socket.close()
         self._server.shutdown()


### PR DESCRIPTION
Running sequential tasks using dispy with http is currently not possible (at least on my machines) because the http server takes too long to shut down; resulting in the error:

socket.error: [Errno 98] Address already in use

This pull request solves this problem.
