### PR TITLE
Only close socket after HttpServer shutdown

### DIFF
--- a/py2/dispy/httpd.py
+++ b/py2/dispy/httpd.py
@@ -299,6 +299,6 @@ class DispyHTTPServer(object):
                 'HTTP server waiting for %s seconds for client updates before quitting',
                 self._poll_sec)
             time.sleep(self._poll_sec)
+        self._server.shutdown()
         if self._server.socket:
             self._server.socket.close()
-        self._server.shutdown()

--- a/py3/dispy/httpd.py
+++ b/py3/dispy/httpd.py
@@ -299,6 +299,6 @@ class DispyHTTPServer(object):
                 'HTTP server waiting for %s seconds for client updates before quitting',
                 self._poll_sec)
             time.sleep(self._poll_sec)
+        self._server.shutdown()
         if self._server.socket:
             self._server.socket.close()
-        self._server.shutdown()


### PR DESCRIPTION
As per our discussion in the other thread, this is probably an acceptable solution.