### PR TITLE
Fixed a typo in error message in JobCluster()

### DIFF
--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -1912,7 +1912,7 @@ class JobCluster(object):
             compute = _Compute(_Compute.prog_type, computation)
             depends.append(computation)
         else:
-            raise Exception('Invalid computation type: %s' % type(compute))
+            raise Exception('Invalid computation type: %s' % type(computation))
 
         if setup:
             if inspect.isfunction(setup):


### PR DESCRIPTION
Passing an invalid computation object to JobCluster.__init__() gets the following:

  File "/usr/local/lib/python2.7/dist-packages/dispy/__init__.py", line 1914, in __init__
    raise Exception('Invalid computation type: %s' % type(compute))
UnboundLocalError: local variable 'compute' referenced before assignment

I'm guessing that the intent was to describe 'computation' in the error message, not 'compute'.