### PR TITLE
adresses pgiri/dispy#39

### DIFF
--- a/py2/dispy/dispynode.py
+++ b/py2/dispy/dispynode.py
@@ -1600,8 +1600,8 @@ if __name__ == '__main__':
         cfgp.read(_dispy_config['config'])
         _dispy_config, cfgp = dict(cfgp.items('DEFAULT')), _dispy_config
         if _dispy_config:
-            for key, value in _dispy_config.items():
-                if cfgp[key] != parser.get_default(key):
+            for key, value in cfgp.items():
+                if cfgp[key] != parser.get_default(key) or key not in _dispy_config:
                     print('set %s to %s' % (key, cfgp[key]))
                     _dispy_config[key] = cfgp[key]
             del key, value

--- a/py3/dispy/dispynode.py
+++ b/py3/dispy/dispynode.py
@@ -1603,8 +1603,8 @@ if __name__ == '__main__':
         cfgp.read(_dispy_config['config'])
         _dispy_config, cfgp = dict(cfgp.items('DEFAULT')), _dispy_config
         if _dispy_config:
-            for key, value in _dispy_config.items():
-                if cfgp[key] != parser.get_default(key):
+            for key, value in cfgp.items():
+                if cfgp[key] != parser.get_default(key) or key not in _dispy_config:
                     print('set %s to %s' % (key, cfgp[key]))
                     _dispy_config[key] = cfgp[key]
             del key, value


### PR DESCRIPTION
This fixes the solution proposed in pgiri/dispy#39.
Instead of iterating all config parser values we need to go through all cli arguments and check whether we have to update the config parser values (which are the ones we use afterwards).