### PR TITLE
gracefully terminate when killed with SIGTERM

### DIFF
--- a/py2/dispy/dispynode.py
+++ b/py2/dispy/dispynode.py
@@ -23,6 +23,7 @@ import functools
 import inspect
 import cPickle as pickle
 import cStringIO as io
+import signal
 try:
     import psutil
 except ImportError:
@@ -1702,5 +1703,10 @@ if __name__ == '__main__':
     _dispy_node = None
     _dispy_node = _DispyNode(**_dispy_config)
     del _dispy_config
+
+    def shutdown(_, __):
+        _dispy_node.shutdown(quit=True)
+
+    signal.signal(signal.SIGTERM, shutdown)
 
     _dispy_node.asyncoro.finish()

--- a/py3/dispy/dispynode.py
+++ b/py3/dispy/dispynode.py
@@ -23,6 +23,7 @@ import functools
 import inspect
 import pickle
 import io
+import signal
 try:
     import psutil
 except ImportError:
@@ -1711,5 +1712,10 @@ if __name__ == '__main__':
     _dispy_node = None
     _dispy_node = _DispyNode(**_dispy_config)
     del _dispy_config
+
+    def shutdown(_, __):
+        _dispy_node.shutdown(quit=True)
+
+    signal.signal(signal.SIGTERM, shutdown)
 
     _dispy_node.asyncoro.finish()


### PR DESCRIPTION
This might be a somewhat hakish solution but this terminates dispynode more smoothly when killed.