### PR TITLE
Example for setup/cleanup fixed

### DIFF
--- a/py2/dispy/examples/node_setup.py
+++ b/py2/dispy/examples/node_setup.py
@@ -14,12 +14,8 @@ def setup(data_file):
 
     import hashlib
 
-    # Building path to the files on the dispy node. Passed files
-    # are stored under the computation path in the working dir
-    # on the dispy node. But into function file paths are passed
-    # as absolute paths on the master node. Thus we should add 
-    # computation path to the master node path.
-    local_data_file = os.path.join(os.getcwd(), context_file.lstrip(os.sep))
+    # If data_file is passed as absolute path we should use only basename
+    local_data_file = os.path.join(os.getcwd(), os.path.os.path.basename(data_file))
     
     data = open(local_data_file).read()  # read file in to memory; data_file can now be deleted
     if sys.version_info.major > 2:

--- a/py2/dispy/examples/node_setup.py
+++ b/py2/dispy/examples/node_setup.py
@@ -13,7 +13,15 @@ def setup(data_file):
     global data, algorithms, hashlib
 
     import hashlib
-    data = open(data_file).read()  # read file in to memory; data_file can now be deleted
+
+    # Building path to the files on the dispy node. Passed files
+    # are stored under the computation path in the working dir
+    # on the dispy node. But into function file paths are passed
+    # as absolute paths on the master node. Thus we should add 
+    # computation path to the master node path.
+    local_data_file = os.path.join(os.getcwd(), context_file.lstrip('/'))
+    
+    data = open(local_data_file).read()  # read file in to memory; data_file can now be deleted
     if sys.version_info.major > 2:
         data = data.encode() # convert to bytes
         algorithms = list(hashlib.algorithms_guaranteed)
@@ -31,9 +39,22 @@ def setup(data_file):
 
 def cleanup():
     global data, algorithms, hashlib
-    del data, algorithms
+    
+    # If setup function is failed some of globals can be undefined
+    try:
+        del data
+    except NameError:
+        pass
+    try:
+        del algorithms
+    except NameError:
+        pass
+    
     if os.name != 'nt':
-        del hashlib
+        try:
+            del hashlib
+        except NameError:
+            pass
 
 def compute(n):
     global hashlib

--- a/py2/dispy/examples/node_setup.py
+++ b/py2/dispy/examples/node_setup.py
@@ -19,7 +19,7 @@ def setup(data_file):
     # on the dispy node. But into function file paths are passed
     # as absolute paths on the master node. Thus we should add 
     # computation path to the master node path.
-    local_data_file = os.path.join(os.getcwd(), context_file.lstrip('/'))
+    local_data_file = os.path.join(os.getcwd(), context_file.lstrip(os.sep))
     
     data = open(local_data_file).read()  # read file in to memory; data_file can now be deleted
     if sys.version_info.major > 2:

--- a/py3/dispy/examples/node_setup.py
+++ b/py3/dispy/examples/node_setup.py
@@ -14,12 +14,8 @@ def setup(data_file):
 
     import hashlib
 
-    # Building path to the files on the dispy node. Passed files
-    # are stored under the computation path in the working dir
-    # on the dispy node. But into function file paths are passed
-    # as absolute paths on the master node. Thus we should add 
-    # computation path to the master node path.
-    local_data_file = os.path.join(os.getcwd(), context_file.lstrip(os.sep))
+    # If data_file is passed as absolute path we should use only basename
+    local_data_file = os.path.join(os.getcwd(), os.path.basename(data_file))
     
     data = open(local_data_file).read()  # read file in to memory; data_file can now be deleted
     if sys.version_info.major > 2:

--- a/py3/dispy/examples/node_setup.py
+++ b/py3/dispy/examples/node_setup.py
@@ -13,7 +13,15 @@ def setup(data_file):
     global data, algorithms, hashlib
 
     import hashlib
-    data = open(data_file).read()  # read file in to memory; data_file can now be deleted
+
+    # Building path to the files on the dispy node. Passed files
+    # are stored under the computation path in the working dir
+    # on the dispy node. But into function file paths are passed
+    # as absolute paths on the master node. Thus we should add 
+    # computation path to the master node path.
+    local_data_file = os.path.join(os.getcwd(), context_file.lstrip(os.sep))
+    
+    data = open(local_data_file).read()  # read file in to memory; data_file can now be deleted
     if sys.version_info.major > 2:
         data = data.encode() # convert to bytes
         algorithms = list(hashlib.algorithms_guaranteed)
@@ -31,9 +39,22 @@ def setup(data_file):
 
 def cleanup():
     global data, algorithms, hashlib
-    del data, algorithms
+    
+    # If setup function is failed some of globals can be undefined
+    try:
+        del data
+    except NameError:
+        pass
+    try:
+        del algorithms
+    except NameError:
+        pass
+    
     if os.name != 'nt':
-        del hashlib
+        try:
+            del hashlib
+        except NameError:
+            pass
 
 def compute(n):
     global hashlib


### PR DESCRIPTION
When files are saved to the node, they stored under the working dir + computation_id path. If on the client files are defined with absolute paths they can't be loaded on the node.
Then setup function is failed some of global variables can be undefined. Cleanup function shouldn't rasise the NameError in case of deletion undefined global variables.