### PR TITLE
Fix invalid DispyJob reference

### DIFF
--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -1717,10 +1717,11 @@ class _Cluster(object, metaclass=Singleton):
                 pass
             else:
                 logger.warning('Invalid reply status: %s for job %s', reply.status, _job.uid)
+            dispy_job = _job.job
+            self.finish_job(cluster, _job, reply.status)
             if cluster.status_callback:
                 self.worker_Q.put((cluster.status_callback,
-                                   (reply.status, dispy_node, _job.job)))
-            self.finish_job(cluster, _job, reply.status)
+                                   (reply.status, dispy_node, dispy_job)))
             self._sched_event.set()
         yield sock.send_msg(b'ACK')
 
@@ -1744,10 +1745,11 @@ class _Cluster(object, metaclass=Singleton):
                 logger.debug('Job %s scheduled on %s abandoned', _job.uid, _job.node.ip_addr)
                 # TODO: it is likely node finishes this job and sends
                 # reply later; keep this in _abandoned_jobs and process reply?
+                dispy_job = _job.job
+                self.finish_job(cluster, _job, DispyJob.Abandoned)
                 if cluster.status_callback and dispy_node:
                     self.worker_Q.put((cluster.status_callback,
-                                       (DispyJob.Abandoned, dispy_node, _job.job)))
-                self.finish_job(cluster, _job, DispyJob.Abandoned)
+                                       (DispyJob.Abandoned, dispy_node, dispy_job)))
         self._sched_event.set()
 
     def run_job(self, _job, cluster, task=None):
@@ -1766,11 +1768,12 @@ class _Cluster(object, metaclass=Singleton):
             if node.pending_jobs:
                 for njob in node.pending_jobs:
                     if njob.compute_id == cluster._compute.id:
+                        dispy_job = njob.job
                         self.finish_job(cluster, njob, DispyJob.Cancelled)
                         if cluster.status_callback and dispy_node:
                             dispy_node.update_time = time.time()
                             self.worker_Q.put((cluster.status_callback,
-                                               (DispyJob.Cancelled, dispy_node, njob.job)))
+                                               (DispyJob.Cancelled, dispy_node, dispy_job)))
                 node.pending_jobs = [njob for njob in node.pending_jobs
                                      if njob.compute_id != cluster._compute.id]
             if self._sched_jobs.pop(_job.uid, None) == _job:
@@ -1785,11 +1788,12 @@ class _Cluster(object, metaclass=Singleton):
             # TODO: delay executing again for some time?
             # this job might have been deleted already due to timeout
             if self._sched_jobs.pop(_job.uid, None) == _job:
+                dispy_job = _job.job
                 self.finish_job(cluster, _job, DispyJob.Cancelled)
                 if cluster.status_callback and dispy_node:
                     dispy_node.update_time = time.time()
                     self.worker_Q.put((cluster.status_callback,
-                                       (DispyJob.Cancelled, dispy_node, _job.job)))
+                                       (DispyJob.Cancelled, dispy_node, dispy_job)))
                 node.busy -= 1
             self._sched_event.set()
         else:
@@ -1865,13 +1869,14 @@ class _Cluster(object, metaclass=Singleton):
                     status = DispyJob.Terminated
                 else:
                     status = DispyJob.Cancelled
+                dispy_job = _job.job
                 self.finish_job(cluster, _job, status)
                 if cluster.status_callback:
                     dispy_node = cluster._dispy_nodes.get(_job.node.ip_addr, None)
                     if dispy_node:
                         dispy_node.update_time = time.time()
                         self.worker_Q.put((cluster.status_callback,
-                                           (status, dispy_node, _job.job)))
+                                           (status, dispy_node, dispy_job)))
             for dispy_node in cluster._dispy_nodes.values():
                 node = self._nodes.get(dispy_node.ip_addr, None)
                 if not node:
@@ -1882,11 +1887,12 @@ class _Cluster(object, metaclass=Singleton):
                         status = DispyJob.Terminated
                     else:
                         status = DispyJob.Cancelled
+                    dispy_job = _job.job
                     self.finish_job(cluster, _job, status)
                     if cluster.status_callback:
                         dispy_node.update_time = time.time()
                         self.worker_Q.put((cluster.status_callback,
-                                           (status, dispy_node, _job.job)))
+                                           (status, dispy_node, dispy_job)))
                 node.pending_jobs = []
             cluster._jobs = []
             cluster._pending_jobs = 0
@@ -1930,9 +1936,10 @@ class _Cluster(object, metaclass=Singleton):
                 _job.pinned.pending_jobs.remove(_job)
             else:
                 cluster._jobs.remove(_job)
-            if cluster.status_callback:
-                self.worker_Q.put((cluster.status_callback, (DispyJob.Cancelled, None, _job.job)))
+            dispy_job = _job.job
             self.finish_job(cluster, _job, DispyJob.Cancelled)
+            if cluster.status_callback:
+                self.worker_Q.put((cluster.status_callback, (DispyJob.Cancelled, None, dispy_job)))
             logger.debug('Cancelled (removed) job %s', _job.uid)
             raise StopIteration(0)
         elif not (_job.job.status == DispyJob.Running or


### PR DESCRIPTION
When finish_job is called with a status other than DispyJob.ProvisionalResult the DispyJob within _DispyJob is set to `None` [here](https://github.com/pgiri/dispy/blob/master/py3/dispy/__init__.py#L667), this means in the current order the cluster.status_callback does not get a valid reference to the DispyJob that is for example cancelled (`status == DispyJob.Cancelled`) which prevents a rescheduling of the job using its id `DispyJob.id`.

Changing the order with this PR resolves the issue of the missing reference, however I think it might introduce a race condition on `DispyJob.status` and `DispyJob._dispy_job_` because it is not guaranteed that [this](https://github.com/pgiri/dispy/blob/master/py3/dispy/__init__.py#L665) code executes before the callback is called. I am not entirely sure about that and since it would also be the case [here](https://github.com/pgiri/dispy/blob/master/py3/dispy/__init__.py#L1723) and I did not modify that code.

Do you think this is a proper fix or can you help me to fix it properly?

Thank you and best wishes

