### PR TITLE
Make zero a valid timeout

### DIFF
--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -3271,7 +3271,7 @@ def recover_jobs(recover_file=None, timeout=None, terminate_pending=False):
         sock.listen(32)
 
         while 1:
-            if pending['timeout']:
+            if pending['timeout'] is not None:
                 timeout = pending['timeout'] - (time.time() - pending['start_time'])
                 if timeout <= 0:
                     pending['complete'].set()
@@ -3295,7 +3295,7 @@ def recover_jobs(recover_file=None, timeout=None, terminate_pending=False):
 
     def resend_requests(pending, task=None):
         for compute_id, compute in computes.items():
-            if pending['timeout'] and \
+            if pending['timeout'] is not None and \
                ((time.time() - pending['start_time']) > pending['timeout']):
                 break
             req = {'compute_id': compute_id, 'auth': compute['auth']}

--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -3275,7 +3275,7 @@ def recover_jobs(recover_file=None, timeout=None, terminate_pending=False):
         sock.listen(32)
 
         while 1:
-            if pending['timeout']:
+            if pending['timeout'] is not None:
                 timeout = pending['timeout'] - (time.time() - pending['start_time'])
                 if timeout <= 0:
                     pending['complete'].set()
@@ -3299,7 +3299,7 @@ def recover_jobs(recover_file=None, timeout=None, terminate_pending=False):
 
     def resend_requests(pending, task=None):
         for compute_id, compute in list(computes.items()):
-            if pending['timeout'] and \
+            if pending['timeout'] is not None and \
                ((time.time() - pending['start_time']) > pending['timeout']):
                 break
             req = {'compute_id': compute_id, 'auth': compute['auth']}


### PR DESCRIPTION
When releasing jobs on might want to use a timeout of zero ("0"), the current implementation does not consider zero a valid timeout.