### PR TITLE
Fix for missing node argument in JobCluster.submit_node() call to JobCluster.submit_job_id_node()

### DIFF
--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -2757,7 +2757,7 @@ class JobCluster(object):
         Arguments should be serializable and should correspond to
         arguments for computation used when cluster is created.
         """
-        return self.submit_job_id_node(None, *args, **kwargs)
+        return self.submit_job_id_node(None, node, *args, **kwargs)
 
     def submit_job_id_node(self, job_id, node, *args, **kwargs):
         """Same as 'submit_node' but job's 'id' is initialized to 'job_id'.

--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -2763,7 +2763,7 @@ class JobCluster(object):
         Arguments should be serializable and should correspond to
         arguments for computation used when cluster is created.
         """
-        return self.submit_job_id_node(None, *args, **kwargs)
+        return self.submit_job_id_node(None, node, *args, **kwargs)
 
     def submit_job_id_node(self, job_id, node, *args, **kwargs):
         """Same as 'submit_node' but job's 'id' is initialized to 'job_id'.


### PR DESCRIPTION
The code for SharedJobCluster.submit_node() is correct, only the JobCluster had a problem in submit_node()