### PR TITLE
Bug fixes for incorrect broadcast IP

### DIFF
--- a/py2/dispy/__init__.py
+++ b/py2/dispy/__init__.py
@@ -407,7 +407,7 @@ def host_addrinfo(host=None, socket_family=None, ipv4_multicast=False):
                         addr = str(link['addr'])
                         broadcast = link.get('broadcast', '<broadcast>')
                         # Windows seems to have broadcast same as addr
-                        if broadcast.startswith(addr):
+                        if broadcast == addr and os.name == 'nt':
                             broadcast = '<broadcast>'
                         try:
                             addrs = socket.getaddrinfo(addr, None, sock_family, socket.SOCK_STREAM)

--- a/py3/dispy/__init__.py
+++ b/py3/dispy/__init__.py
@@ -413,7 +413,7 @@ def host_addrinfo(host=None, socket_family=None, ipv4_multicast=False):
                         addr = str(link['addr'])
                         broadcast = link.get('broadcast', '<broadcast>')
                         # Windows seems to have broadcast same as addr
-                        if broadcast.startswith(addr):
+                        if broadcast == addr and os.name == 'nt':
                             broadcast = '<broadcast>'
                         try:
                             addrs = socket.getaddrinfo(addr, None, sock_family, socket.SOCK_STREAM)


### PR DESCRIPTION
1) prevent correct broadcast from being overwritten
- Bug example: 142.1.136.6's correct broadcast IP is 142.1.136.63, therefore shouldn't go into this branch
2) restrict Windows platform only edge case to Windows platform