### PR TITLE
Bsync import dependencies

### DIFF
--- a/py3/__init__.py
+++ b/py3/__init__.py
@@ -2741,18 +2741,20 @@ class JobCluster(object):
 
         for dep in depends:
             if isinstance(dep, str):
-                if not os.path.isfile(dep) and compute.type == _Compute.prog_type:
-                    for p in os.environ['PATH'].split(os.pathsep):
-                        f = os.path.join(p, dep)
-                        if os.path.isfile(f):
-                            logger.debug('Assuming "%s" is program "%s"', dep, f)
-                            dep = f
-                            break
-                try:
-                    compute.xfer_files.append(_XferFile(dep, compute.id))
-                except Exception:
-                    raise Exception('File "%s" is not valid' % dep)
-
+                if dep.startswith("import "):
+                    compute.code = f"{dep}\n{compute.code}"
+                else:
+                    if not os.path.isfile(dep) and compute.type == _Compute.prog_type:
+                        for p in os.environ['PATH'].split(os.pathsep):
+                            f = os.path.join(p, dep)
+                            if os.path.isfile(f):
+                                logger.debug('Assuming "%s" is program "%s"', dep, f)
+                                dep = f
+                                break
+                    try:
+                        compute.xfer_files.append(_XferFile(dep, compute.id))
+                    except Exception:
+                        raise Exception('File "%s" is not valid' % dep)
             elif inspect.ismodule(dep):
                 try:
                     compute.xfer_files.append(_XferFile(dep, compute.id))

--- a/py3/examples/obj_instances.py
+++ b/py3/examples/obj_instances.py
@@ -1,6 +1,7 @@
 # example program that sends object instances in local program
 # as arguments to distributed computation
-class C:
+import cmd
+class C(cmd.Cmd):
     def __init__(self, i, n):
         self.i = i
         self.n = n
@@ -17,7 +18,11 @@ def compute(obj):
 
 if __name__ == '__main__':
     import random, dispy
-    cluster = dispy.JobCluster(compute, depends=[C])
+    def nodeinit_setup():
+        global cmd
+        import cmd
+        return 0
+    cluster = dispy.JobCluster(compute, depends=[C], setup=nodeinit_setup)
     jobs = []
     for i in range(10):
         c = C(i, random.uniform(1, 3)) # create object of C

--- a/py3/examples/obj_instances.py
+++ b/py3/examples/obj_instances.py
@@ -17,12 +17,8 @@ def compute(obj):
     return obj.n
 
 if __name__ == '__main__':
-    import random, dispy
-    def nodeinit_setup():
-        global cmd
-        import cmd
-        return 0
-    cluster = dispy.JobCluster(compute, depends=[C], setup=nodeinit_setup)
+    import random, dispy    
+    cluster = dispy.JobCluster(compute, depends=["import cmd", C])
     jobs = []
     for i in range(10):
         c = C(i, random.uniform(1, 3)) # create object of C


### PR DESCRIPTION
Small modification to directly support 'import <...>' type strings as JobCluster dependencies.  They are always prefixed to the compute.code and serialized as is to the compute node(s).